### PR TITLE
Enhancement #9: Implement Threading Locks

### DIFF
--- a/config/config_default.yml
+++ b/config/config_default.yml
@@ -58,6 +58,8 @@ gps:
     simulate: False
 eps:
     simulate: False
+radio_output:
+    sleep_interval: 10
 housekeeping:
     beacon_period: 60
     low_power_period: 120

--- a/config/config_default.yml
+++ b/config/config_default.yml
@@ -58,6 +58,7 @@ gps:
     simulate: False
 eps:
     simulate: False
+# Wait interval so that APRS and Iridium buffers can be cleared
 radio_output:
     sleep_interval: 10
 housekeeping:

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -40,6 +40,7 @@ def load_config():
 
 
 def get_config():
+    """Returns the configuration data from config_*.yml as a list"""
     return config
 
 

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,8 +2,8 @@ import importlib
 import logging
 import os
 import time
-
 import yaml
+
 
 from core.mode import Mode
 from core.power import Power
@@ -36,6 +36,10 @@ def load_config():
         with open('config/config_default.yml') as f:
             config = yaml.load(f)
 
+    return config
+
+
+def get_config():
     return config
 
 

--- a/submodules/radio_output/__init__.py
+++ b/submodules/radio_output/__init__.py
@@ -1,18 +1,27 @@
-from submodules.aprs import aprs
+from threading import Lock
+from time import sleep
+
+from submodules import aprs
 from submodules import iridium
+from core import get_config
 
-default_radio: str = "aprs"
+"""
+send_lock is a threading lock that only allows one process to access a resource
+"""
+send_lock = Lock()
+
+"""
+Send a message back to the groundstation.
+:param message: Message to send to the radio.
+:param radio: Radio to which to send the message. If `None`, send to the default radio.
+"""
 
 
-def send(message: str, radio=None):
-    """
-    Send a message back to the groundstation.
-    :param message: Message to send to the radio.
-    :param radio: Radio to which to send the message. If `None`, send to the default radio.
-    """
-    if radio is None:
-        radio = default_radio
-    if radio == "aprs":
-        aprs.send(message)
-    if radio == "iridium":
-        iridium.send(message)
+def send(message: str, radio="aprs"):
+    with send_lock: # When a process tries to access this method, it must receive the lock before continuing
+        if radio == "iridium":
+            iridium.send(message)
+        else:
+            aprs.send(message)
+        sleep(get_config()['radio_output']['sleep_interval']) # Wait until APRS and Iridium buffers are cleared
+    # At this point the lock has been released

--- a/submodules/radio_output/__init__.py
+++ b/submodules/radio_output/__init__.py
@@ -8,7 +8,7 @@ from core import get_config
 """
 send_lock is a threading lock that only allows one process to access a resource
 """
-send_lock = Lock()
+send_lock = Lock() # Instance of threading lock
 
 """
 Send a message back to the groundstation.
@@ -20,8 +20,8 @@ Send a message back to the groundstation.
 def send(message: str, radio="aprs"):
     with send_lock: # When a process tries to access this method, it must receive the lock before continuing
         if radio == "iridium":
-            iridium.send(message)
+            iridium.send(message) # Send through Iridium
         else:
-            aprs.send(message)
+            aprs.send(message) # Send through APRS
         sleep(get_config()['radio_output']['sleep_interval']) # Wait until APRS and Iridium buffers are cleared
     # At this point the lock has been released


### PR DESCRIPTION
# Implement Threading Locks
#9 
## Description
Added threading locks to `radio_output.py` so that two processes cannot access a radio at the same time.

## Steps to Reproduce
1. Spawn two threads that call `radio_output.send(message: str)`
2. Start both threads
3. The later thread should not be able to access `radio_output.send(message: str)` until the previous thread has died

## Affected Areas
 - `radio_output.py`
 - `core/__init__.py`
 - `config_default.yml`