### PR TITLE
Enhancement #10: Implement telemetry dump interval

### DIFF
--- a/config/config_default.yml
+++ b/config/config_default.yml
@@ -12,6 +12,7 @@ core:
             - housekeeping
             - telemetry
     config_save_interval: 60
+    dump_interval: 10
 adcs:
     koe:
         argp: 33.54134

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -116,7 +116,7 @@ def start():
     state = None
 
     #Telemetry dump after x seconds
-    t = threading.Timer(config['core']['dump_interval'], telemetry.dump()) #method: telemetry.dump() not a method right now
+    t = threading.Timer(config['core']['dump_interval'], telemetry.dump) #method: telemetry.dump() not a method right now
     t.start()
 
     # logger.debug(f"Config: {config}")

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,7 +2,6 @@ import importlib
 import logging
 import os
 import time
-import threading
 import yaml
 
 from core.mode import Mode
@@ -10,6 +9,8 @@ from core.power import Power
 from submodules import eps
 # from submodules import command_ingest
 # from submodules import aprs
+from functools import partial
+from threading import Timer
 from submodules import telemetry
 # from submodules import antenna_deploy
 from submodules.command_ingest import command
@@ -116,7 +117,7 @@ def start():
     state = None
 
     #Telemetry dump after x seconds
-    t = threading.Timer(config['core']['dump_interval'], telemetry.dump) #method: telemetry.dump() not a method right now
+    t = Timer(config['core']['dump_interval'], partial(telemetry.dump)) #method: telemetry.dump() not a method right now
     t.start()
 
     # logger.debug(f"Config: {config}")

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -6,11 +6,11 @@ import yaml
 
 from core.mode import Mode
 from core.power import Power
+from functools import partial
+from threading import Timer
 from submodules import eps
 # from submodules import command_ingest
 # from submodules import aprs
-from functools import partial
-from threading import Timer
 from submodules import telemetry
 # from submodules import antenna_deploy
 from submodules.command_ingest import command

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,7 +2,7 @@ import importlib
 import logging
 import os
 import time
-
+import threading
 import yaml
 
 from core.mode import Mode
@@ -10,7 +10,7 @@ from core.power import Power
 from submodules import eps
 # from submodules import command_ingest
 # from submodules import aprs
-# from submodules import telemetry
+from submodules import telemetry
 # from submodules import antenna_deploy
 from submodules.command_ingest import command
 
@@ -114,6 +114,10 @@ def start():
     # Load `config` from either default file or persistent config
     config = load_config()
     state = None
+
+    #Telemetry dump after x seconds
+    t = threading.Timer(config['core']['dump_interval'], telemetry.dump()) #method: telemetry.dump() not a method right now
+    t.start()
 
     # logger.debug(f"Config: {config}")
 


### PR DESCRIPTION
# Implement telemetry dump interval
#10 
## Description
Added a telemetry Timer in `__init__.py` that will call on `telemetry.dump()` every `X` seconds/minutes/hours. This interval was recorded in `core/config_default.yml`.
## Steps to Test
- Open up Python3 and `from threading import Timer`
- Define a dummy `telemetry.dump` method
- Instantiate a threading Timer object using `t = threading.Timer(10, telemetry.dump)`.
- Start the timer using `t.start()`
- The Timer object should execute `telemetry.dump()` after 10 seconds.
## Affected Areas
- `__init__.py`
- `core/config_default.yml`