### PR TITLE
Telemetry rewrite

### DIFF
--- a/core/error.py
+++ b/core/error.py
@@ -1,11 +1,26 @@
 from datetime import datetime
 
+
 class Error():
-    def __init__(self, sys_name='CORE', ts=datetime.utcnow(), msg=None):
+    """
+    A class representing error messages.
+    """
+
+    def __init__(self, sys_name='CORE', ts: datetime = datetime.utcnow(), msg: str = None):
+        """
+        Constructor.
+        :param sys_name: The name of the subsystem.
+        :param ts: A timestamp in datetime format.
+        :param msg: A string representing the message.
+        """
         self.system = sys_name
         self.timestamp = ts
         self.message = msg
         self.header = 'ERR!'
-    def to_string(self):
-        return "{0}:{1}:{2}:{3}".format(self.header, self.system, 
-            self.timestamp.strftime("%Y/%m/%d@%H.%M.%S"), self.message)
+
+    def to_string(self) -> str:
+        """
+        :return: A string representation of this error.
+        """
+        return "{0}:{1}:{2}:{3}".format(self.header, self.system,
+                                        self.timestamp.strftime("%Y/%m/%d@%H.%M.%S"), self.message)

--- a/core/log.py
+++ b/core/log.py
@@ -1,12 +1,28 @@
 from datetime import datetime
 
+
 class Log():
-    def __init__(self, sys_name='CORE', lvl='INFO', ts=datetime.utcnow(), msg=None):
+    """
+    A class representing log messages.
+    """
+
+    def __init__(self, sys_name: str = 'CORE', lvl: str = 'INFO', ts: datetime = datetime.utcnow(), msg: str = None):
+        """
+        Constructor.
+        :param sys_name: Subsystem name
+        :param lvl: Level of message (info, warning, error)
+        :param ts: Timestamp in datetime format.
+        :param msg: String message
+        """
         self.system = sys_name
         self.level = lvl
         self.timestamp = ts
         self.message = msg
         self.header = 'LOG&'
+
     def to_string(self):
+        """
+        :return: String representation of log message.
+        """
         return "{0}:{1}:{2}:{3}:{4}".format(self.header, self.system, self.level,
-            self.timestamp.strftime("%Y/%m/%d@%H%M%S"), self.message)
+                                            self.timestamp.strftime("%Y/%m/%d@%H%M%S"), self.message)

--- a/submodules/radio_output/__init__.py
+++ b/submodules/radio_output/__init__.py
@@ -1,4 +1,4 @@
-from submodules.aprs import aprs
+from submodules import aprs
 from submodules import iridium
 
 default_radio: str = "aprs"

--- a/submodules/telemetry/README.md
+++ b/submodules/telemetry/README.md
@@ -1,0 +1,36 @@
+Tasks
+======
+Data Structures
+------------------------
+- `general_queue` (type: [Queue](https://docs.python.org/3/library/queue.html))
+- `log_stack` (type: [Stack](https://docs.python.org/3/tutorial/datastructures.html#using-lists-as-stacks))
+- `err_stack` (type: [Stack](https://docs.python.org/3/tutorial/datastructures.html#using-lists-as-stacks))
+
+Methods (excluding helpers)
+---------------
+ - `enqueue(message: str)`
+   - PUSH message onto general_queue
+ - `dump()`
+   - Convert log_stack and err_stack into strings
+   - Encode generated string with base64
+   - Add prefixes and postfixes
+   - Send final string through radio_output.send()
+
+Threads
+-------------
+- `decide()`
+   - WHILE True:
+   - if len(general_queue) > 0
+     - POP message from general_queue
+     - if message == CMD
+       - command_ingest.enqueue(message)
+     - if message == LOG
+       - PUSH message onto log_stack
+     - if message == ERR
+       - PUSH message onto err_stack   - POP message from general_queue
+     - if message == CMD
+       - command_ingest.enqueue(message)
+     - if message == LOG
+       - PUSH message onto log_stack
+     - if message == ERR
+       - PUSH message onto err_stack

--- a/submodules/telemetry/TESTING.py
+++ b/submodules/telemetry/TESTING.py
@@ -1,0 +1,57 @@
+"""
+README BEFORE USING
+Telemetry's __init__.py must be changed in several places before using this.
+
+* The reference to the config file in dump()'s while loop must be changed to a number, not referencing config.
+* radio_output.send() in the dump() method must be changed with a print statement.
+    Alternatively, radio_output.send() can be changed similarly.
+* Command_ingest.enqueue() should be commented out or replaced with a dummy thing.
+* The two lines at the end of start() that start the decide() thread should be commented out, and the while-True
+    loop in decide() must be commented out. Indents need to be fixed accordingly.
+    This script runs decide() as a one-off method
+
+"""
+
+"""
+A script to test telemetry. Changes must be made as above before using.
+When "ready" is printed, type any one of:
+
+* ee - enqueue an error
+* el - enqueue a log
+* eXXX where XXX is any text - run telemetry.enqueue(XXX)
+* d - run a dump
+* p - print the general queue, error stack, and log stack in that order
+* c - clear buffers
+
+"""
+
+import threading
+from datetime import datetime
+from functools import partial
+
+from submodules import telemetry
+from core import error, log
+
+def main():
+    while True:
+        print("Ready")
+        c = input()
+        if c[0] == 'e':
+            if c[1] == 'e':
+                telemetry.enqueue(error.Error("TEST", datetime.utcnow(), "testing"))
+            elif c[1] == 'l':
+                telemetry.enqueue(log.Log("TEST", "INFO", datetime.utcnow(), "testinglog"))
+            else:
+                telemetry.enqueue(c[1:])
+            telemetry.decide()
+        elif c[0] == 'd':
+            telemetry.dump()
+        elif c[0] == 'p':
+            print(telemetry.general_queue, telemetry.err_stack, telemetry.log_stack)
+        elif c[0] == 'c':
+            telemetry.clear_buffers()
+
+
+if __name__ == '__main__':
+    telemetry.start()
+    main()

--- a/submodules/telemetry/TESTING.py
+++ b/submodules/telemetry/TESTING.py
@@ -18,17 +18,14 @@ When "ready" is printed, type any one of:
 
 * ee - enqueue an error
 * el - enqueue a log
-* eXXX where XXX is any text - run telemetry.enqueue(XXX)
+* eXXX where XXX is any text that begins with a semicolon - run telemetry.enqueue(XXX)
 * d - run a dump
 * p - print the general queue, error stack, and log stack in that order
 * c - clear buffers
 
 """
 
-import threading
 from datetime import datetime
-from functools import partial
-
 from submodules import telemetry
 from core import error, log
 

--- a/submodules/telemetry/__init__.py
+++ b/submodules/telemetry/__init__.py
@@ -30,7 +30,7 @@ packet_lock = Lock()
 def enqueue(message) -> None:
     """
     Enqueue a message onto the general queue, to be processed later by thread decide()
-    :param message: The message to push onto general queue, log/error class
+    :param message: The message to push onto general queue, log/error class, or command (string - must begin with semicolon, see command_ingest's readme)
     :return: Nothing
     """
     if not ((type(message) is str and message[0] == ';') or type(message) is error.Error or type(message) is log.Log):
@@ -80,8 +80,7 @@ def decide() -> None:
     :return: Nothing
     """
     global packet_lock
-    # while True:
-    if len(general_queue) > 0:
+    while True:
         with packet_lock:
             message = general_queue.popleft()
             if type(message) is str and message[0] == ';':

--- a/submodules/telemetry/__init__.py
+++ b/submodules/telemetry/__init__.py
@@ -45,14 +45,16 @@ def dump(radio='aprs') -> None:
     global packet_lock, log_stack, err_stack
     squishedpackets = ""
 
-    # with packet_lock:
-    #     while len(log_stack) + len(err_stack) > 0:
-    #         if
-    #
-    #         radio_output.send(squishedpackets, radio)
-    #         squishedpackets = ""
-
-    #TODO: implement
+    with packet_lock:
+        while len(log_stack) + len(err_stack) > 0:
+            while len(squishedpackets) < config["telemetry"]["max_packet_size"] and len(log_stack) + len(err_stack) > 0:
+                if len(err_stack) > 0:
+                    squishedpackets += err_stack.pop()
+                else:
+                    squishedpackets += log_stack.pop()
+            squishedpackets = base64.b64encode(squishedpackets)
+            radio_output.send(squishedpackets, radio)
+            squishedpackets = ""
 
 
 @command("telem_clear")

--- a/submodules/telemetry/__init__.py
+++ b/submodules/telemetry/__init__.py
@@ -78,8 +78,8 @@ def decide() -> None:
     """
     global packet_lock, err_stack, log_stack, general_queue
     while True:
-        with packet_lock:
-            if len(general_queue) != 0:
+        if len(general_queue) != 0:
+            with packet_lock:
                 message = general_queue.popleft()
                 if type(message) is str and message[0] == ';':
                     command_ingest.enqueue(message)
@@ -90,6 +90,7 @@ def decide() -> None:
                     log_stack.append(message)
                 else:  # Shouldn't execute (enqueue() should catch it) but here just in case
                     logger.error("Message prefix invalid.")
+        sleep(1)
 
 
 def start() -> None:

--- a/submodules/telemetry/__init__.py
+++ b/submodules/telemetry/__init__.py
@@ -1,11 +1,6 @@
-# TODO: Uses placeholder variables in other files, so make it use actual values
-# TODO: what if radio turned off during a burst?
 import base64
 import collections
 import logging
-import struct
-import time
-import core
 from functools import partial
 from threading import Lock
 
@@ -14,153 +9,120 @@ from core.mode import Mode
 from core import config
 from core.threadhandler import ThreadHandler
 from submodules import radio_output
+from submodules import command_ingest
+
+# Command Ingest - ability to register commands
 from submodules.command_ingest import command
+
+# Log and error classes
+from core import error, log
 
 
 logger = logging.getLogger("TELEMETRY")
 
-telem_packet_buffer = collections.deque(
-    maxlen=config['telemetry']['buffer_size'])
-event_packet_buffer = collections.deque(
-    maxlen=config['telemetry']['buffer_size'])
-packetBuffers = [event_packet_buffer, telem_packet_buffer]
-# TODO: Use an indexed system so that we have persistent log storage and querying
+general_queue = collections.deque()
+log_stack = collections.deque()
+err_stack = collections.deque()
+
 packet_lock = Lock()
 
-# FIXME: Rename to telemetry_send_loop()
-def telemetry_send():
+def enqueue(message: str) -> None:
     """
-    Thread method to burst the telemetry every so often
+    Enqueue a message onto the general queue, to be processed later by thread decide()
+    :param message: The message to push onto general queue
+    :return: Nothing
     """
-    # TODO: check battery levels before sending
-    global telem_packet_buffer, event_packet_buffer
-    time.sleep(60)  # Don't send packets straight away
+    general_queue.append(message)
 
-    while core.get_state() == Mode.NORMAL:
-        # TODO if (adcs.can_TJ_be_seen() == True and len(telem_packet_buffer) + len(event_packet_buffer) > 0):
-        if len(telem_packet_buffer) + len(event_packet_buffer) > 0:
-            telemetry_send_once()
-        time.sleep(config['telemetry']['send_interval'])
-
-
-# FIXME: Rename to telemetry_send()
-def telemetry_send_once():
+@command("telem_dump")
+def dump(radio='aprs') -> None:
     """
-    Immediately send telemetry packets in both telemetry and event packet queues
+    Concatenates packets to fit in max_packet_size (defined in config) and send through the radio, removing the
+    packets in the process
+    :param radio: Radio to send telemetry through, either "aprs" or "iridium"
+    :return None
     """
-    global telem_packet_buffer, event_packet_buffer
-    beg_count = len(telem_packet_buffer) + len(event_packet_buffer)
-    send()
-    logger.debug("Sent " + str(beg_count - len(telem_packet_buffer) -
-                               len(event_packet_buffer)) + " telemetry packets")
-
-
-@command("telem_burst")
-def telemetry_burst_command():
-    """
-    Burst command; ignores isTJseen and other checks.
-    """
-    send(ignoreADCS=True)
-
-
-def enqueue_event_message(event):
-    """
-    Enqueue an event message.
-    Event messages are a code representing the error, for instance "I01" for IMU error #1 which is to be looked up in a table upon receipt.
-    :param event: message to enqueue following code above. There is a table of codes in Google Sheets. Maximum three bytes.
-    """
-
-    if len(event.encode('utf-8')) != 3:
-        logger.error("Event message larger than 3 bytes, message is " +
-                     str(len(event.encode('utf-8'))) + " bytes long")
-        return
-
-    global event_packet_buffer, packet_lock
-    with packet_lock:
-        packet = "Z"
-        packet += str(base64.b64encode(struct.pack('d', time.time())))
-        packet += str(base64.b64encode(event))
-        event_packet_buffer.append(packet)
-
-
-def enqueue_submodule_packet(packet):
-    """
-    Accepts a single raw string packet and enqueues them into the telemetry packet buffer.
-    :param packet: A correctly formatted string subpacket to enqueue.
-    """
-    global telem_packet_buffer, packet_lock
-    with packet_lock:
-        telem_packet_buffer.append(packet)
-
-
-def enqueue_submodule_packets(packets):
-    """
-    Accepts raw string packets and enqueues them into the telemetry packet buffer.
-    :param packets: A list of string subpackets to enqueue. These packets must be formatted correctly
-    """
-    global telem_packet_buffer, packet_lock
-    with packet_lock:
-        for packet in packets:
-            telem_packet_buffer.append(packet)
-
-
-def send(ignoreADCS=False, radio='aprs'):
-    """
-    Concatenates packets to fit in max_packet_size (defined in config) and send through the APRS, dequing the packets in the process
-    :param ignoreADCS: If true, ignores ADCS canTJBeSeen.
-    :param radio: Radio to send telemetry over, either "aprs" or "iridium"
-    """
-    global packetBuffers, event_packet_buffer, telem_packet_buffer, packet_lock
+    global packet_lock, log_stack, err_stack
     squishedpackets = ""
 
-    with packet_lock:
-        # packet_lock.acquire()
-        # TODO while len(event_packet_buffer) + len(telem_packet_buffer) > 0 and (adcs.can_TJ_be_seen() or ignoreADCS):
-        while len(event_packet_buffer) + len(telem_packet_buffer) > 0:
-            for buffer in packetBuffers:
-                # TODO while len(buffer) > 0 and len(squishedPackets) < config['telemetry']['max_packet_size'] and (adcs.can_TJ_be_seen() or ignoreADCS):
-                while len(buffer) > 0 and len(squishedpackets) < config['telemetry']['max_packet_size']:
-                    # test = buffer.pop()
-                    # print(test)
-                    # squishedPackets += test
-                    squishedpackets += buffer.pop()
+    # with packet_lock:
+    #     while len(log_stack) + len(err_stack) > 0:
+    #         if
+    #
+    #         radio_output.send(squishedpackets, radio)
+    #         squishedpackets = ""
 
-            # TODO: alternate between radios
-            logger.debug(squishedpackets)
-            radio_output.send(squishedpackets, radio)
-            squishedpackets = ""
-            time.sleep(6)
-
-    # packet_lock.release()
+    #TODO: implement
 
 
 @command("telem_clear")
-def clear_buffers():
-    global packet_lock, event_packet_buffer, telem_packet_buffer
+def clear_buffers() -> None:
+    """
+    Clear the telemetry buffers - clearing general_queue, the log, and error stacks.
+    :return: Nothing
+    """
+    global packet_lock, log_stack, err_stack, general_queue
     with packet_lock:
-        event_packet_buffer.clear()
-        telem_packet_buffer.clear()
+        general_queue.clear()
+        log_stack.clear()
+        err_stack.clear()
+
+
+def decide() -> None:
+    """
+    A thread method to constantly check general_queue for messages and process them if there are any.
+    :return: Nothing
+    """
+    global packet_lock
+    while True:
+        if len(general_queue) > 0:
+            with packet_lock:
+                message = general_queue.popleft()
+                if len(message) < 5:    # Messages have to be longer than five characters because the first four
+                                        # characters have to identify the type of message
+                    logger.error("Message too short for it to be a valid message.")
+                else:
+                    if message[0:4] == "CMD$":
+                        command_ingest.enqueue(message[4:])
+                    elif message[0:4] == "ERR!":
+                        err_stack.append(message)
+                    elif message[0:4] == "LOG&":
+                        log_stack.append(message)
+                    else:   # Shouldn't execute (enqueue() should catch it) but here just in case
+                        logger.error("Message prefix invalid.")
 
 
 def start():
     """
     Starts the telemetry send thread
     """
-    t2 = ThreadHandler(target=partial(telemetry_send),
-                       name="telemetry-telemetry_send")
-    t2.start()
+    threadDecide = ThreadHandler(target=partial(decide()),
+                       name="telemetry-decide")
+    threadDecide.start()
 
 
-def enter_normal_mode():
+def enter_normal_mode() -> None:
+    """
+    Enter normal mode.
+    :return: None
+    """
     global state
     state = Mode.NORMAL
 
 
-def enter_low_power_mode():
+def enter_low_power_mode() -> None:
+    """
+    Enter low power mode.
+    :return: None
+    """
     global state
     state = Mode.LOW_POWER
 
 
-def enter_emergency_mode():
+def enter_emergency_mode() -> None:
+    """
+    Enter emergency mode.
+    :return: None
+    """
     global state
     state = Mode.EMERGENCY

--- a/submodules/telemetry/__init__.py
+++ b/submodules/telemetry/__init__.py
@@ -24,9 +24,9 @@ logger = logging.getLogger("TELEMETRY")
 def enqueue(message) -> None:
     """
     Enqueue a message onto the general queue, to be processed later by thread decide()
-    :param message: The message to push onto general queue, log/error class,
+    :param message: The message to push onto general queue. Must be a log/error class
     or command (string - must begin with semicolon, see command_ingest's readme)
-    :return: Nothing
+    :return None
     """
     global packet_lock, general_queue
     if not ((type(message) is str and message[0] == ';') or type(message) is error.Error or type(message) is log.Log):
@@ -61,7 +61,7 @@ def dump(radio='aprs') -> None:
 def clear_buffers() -> None:
     """
     Clear the telemetry buffers - clearing general_queue, the log, and error stacks.
-    :return: Nothing
+    :return: None
     """
     global packet_lock, log_stack, err_stack, general_queue
     with packet_lock:
@@ -73,7 +73,7 @@ def clear_buffers() -> None:
 def decide() -> None:
     """
     A thread method to constantly check general_queue for messages and process them if there are any.
-    :return: Nothing
+    :return: None
     """
     global packet_lock, err_stack, log_stack, general_queue
     while True:
@@ -89,9 +89,10 @@ def decide() -> None:
                 logger.error("Message prefix invalid.")
 
 
-def start():
+def start() -> None:
     """
     Starts the telemetry send thread
+    :return None
     """
     global err_stack, log_stack, general_queue, packet_lock
     general_queue = collections.deque()  # initialize global variables


### PR DESCRIPTION
# Rewrite telemetry
Issue #7 

## Description
Rewrite telemetry to meet the specification as stated in the above issue, and implement Jason's error and logging classes. Meet the command specification as stated in command_ingest's README.

## Steps to Reproduce
1. Calls made to `telemetry.enqueue()` should enqueue the message (error, log, command) to `general_queue`.
2. The thread `decide()` should remove messages to `general_queue` as they come in and, depending on the format (error, log, command) send them to the error stack, log stack, or `command_ingest` respectively.
3. When `dump()` is called, subpackets from the error stack and the log stack (in that order) should be popped off their stacks, converted to their string representations, and concatenated until a maximum size is set (defined in config). This is then encoded to base64 and sent through the APRS (radio_output).
4. When `clear_buffers` is called, the two stacks and the general queue should be cleared.

## Affected Areas
* `core/error.py` (comments, stylistic changes)
* `core/log.py` (same)
* `submodules/radio_output/__init__.py` (fix the first import line)
* `submodules/telemetry/README.md` (readme)
* `submodules/telemetry/__init__.py`