### PR TITLE
enhancement-27

### DIFF
--- a/config/config_new_default.yml
+++ b/config/config_new_default.yml
@@ -17,9 +17,15 @@ aprs:
     telem_timeout: 70
     message_spacing: 1
 eps:
+    looptime: 20
 telemetry:
     send_interval: 30
     buffer_size: 100
     max_packet_size: 170
 iridium:
     serial_port: /dev/ttyUSB0
+antenna:
+    ANT_1: 0
+    ANT_2: 1
+    ANT_3: 2
+    ANT_4: 3

--- a/submodules/antenna_deploy/__init__.py
+++ b/submodules/antenna_deploy/__init__.py
@@ -1,5 +1,5 @@
 from . import isisants
-
+from core import config
 
 def start():
     # Initiate connection with the device
@@ -9,11 +9,7 @@ def start():
     isisants.py_k_ants_arm()
 
     # Run the deploy methods
-    ANT_1 = 0
-    ANT_2 = 1
-    ANT_3 = 2
-    ANT_4 = 3
-    isisants.py_k_ants_deploy(ANT_1, False, 5)
-    isisants.py_k_ants_deploy(ANT_2, False, 5)
-    isisants.py_k_ants_deploy(ANT_3, False, 5)
-    isisants.py_k_ants_deploy(ANT_4, False, 5)
+    isisants.py_k_ants_deploy(config['antenna']['ANT_1'], False, 5)
+    isisants.py_k_ants_deploy(config['antenna']['ANT_2'], False, 5)
+    isisants.py_k_ants_deploy(config['antenna']['ANT_3'], False, 5)
+    isisants.py_k_ants_deploy(config['antenna']['ANT_4'], False, 5)

--- a/submodules/aprs/__init__.py
+++ b/submodules/aprs/__init__.py
@@ -24,7 +24,6 @@ logger = logging.getLogger("APRS")
 last_telem_time = time.time()
 last_message_time = time.time()
 
-bperiod = 60
 ser = None  # Initialize serial
 
 ser_master, ser_slave = pty.openpty()  # Serial ports for when in simulate mode

--- a/submodules/eps/__init__.py
+++ b/submodules/eps/__init__.py
@@ -135,7 +135,6 @@ def get_board_telem(data):
 
 
 def led_on_off() -> None:  # TODO: Delete this method, from eps testing with fake eps
-    looptime = 20  # FIXME: Was 30
     while True:
         pin_on('aprs')
         time.sleep(config['eps']['looptime'])

--- a/submodules/eps/__init__.py
+++ b/submodules/eps/__init__.py
@@ -7,6 +7,7 @@ from functools import partial
 
 from core.mode import Mode
 from core.threadhandler import ThreadHandler
+from core import config
 
 # Initialize global variables
 logger = logging.getLogger("EPS")
@@ -137,9 +138,9 @@ def led_on_off() -> None:  # TODO: Delete this method, from eps testing with fak
     looptime = 20  # FIXME: Was 30
     while True:
         pin_on('aprs')
-        time.sleep(looptime)
+        time.sleep(config['eps']['looptime'])
         pin_off('aprs')
-        time.sleep(looptime)
+        time.sleep(config['eps']['looptime'])
 
 
 def board_check() -> None:


### PR DESCRIPTION
# Standardize Constants
Enhancement #27 

## Description
* Moved the constants `ANT_1`, `ANT_2`, `ANT_3`, and `ANT_4` from `submodules/antenna_deploy/__init__.py` into `config/config_new_default.yml'
* Deleted `submodules/aprs/test.py' because it was an empty file
* Deleted the variable bperiod in `submodules/aprs/__init__.py` because it is never used
* Moved the constant `looptime` from `submodules/eps/__init__.py` into `config/config_new_default.yml' (looptime's value was 20 but there was a comment on that line saying "FIXME: was 30" -- might be important)

## Steps to Reproduce
N/A

## Affected Areas
* `submodules/aprs/test.py' (deleted)
* `config/config_new_default.yml' (added constants)
* `submodules/antenna_deploy/__init__.py` (moved constants)
* `submodules/eps/__init__.py`(moved constants)
