### PR TITLE
Updated Antenna Deployer Class Structure

### DIFF
--- a/submodules/antenna_deploy/__init__.py
+++ b/submodules/antenna_deploy/__init__.py
@@ -4,11 +4,15 @@ from helpers import log
 
 class AntennaDeployer:
 
-    def __init__(self, config):
+    def __init__(self, config: dict):
         self.config = config
-        self.modules = {}
+        self.modules = dict()
 
-    def set_modules(self, dependencies):
+    @property
+    def has_modules(self):
+        return len(self.modules) > 0
+
+    def set_modules(self, dependencies: dict):
         self.modules = dependencies
 
     def start(self):
@@ -23,4 +27,7 @@ class AntennaDeployer:
         isisants.py_k_ants_deploy(self.config['antenna']['ANT_2'], False, 5)
         isisants.py_k_ants_deploy(self.config['antenna']['ANT_3'], False, 5)
         isisants.py_k_ants_deploy(self.config['antenna']['ANT_4'], False, 5)
-        self.modules["telemetry"].enqueue(log.Log(sys_name="antenna_deployer", lvl='INFO', msg="antenna deployed"))
+        if self.has_modules:
+            self.modules["telemetry"].enqueue(log.Log(sys_name="antenna_deployer", lvl='INFO', msg="antenna deployed"))
+        else:
+            raise RuntimeError("Modules not set")


### PR DESCRIPTION
#42 
# Description
Added a `has_modules` property to `AntennaDeployer` and propogated a `RuntimeError` when `self.modules` is not set
